### PR TITLE
Fix typo which causes an error

### DIFF
--- a/bin/space2underscore
+++ b/bin/space2underscore
@@ -12,7 +12,7 @@ underscore_include_sentence = Space2underscore.convert(args)
 
 return puts Space2underscore.usage if ARGV.empty?
 
-if convert_flag.emtpy?
+if convert_flag.empty?
   puts underscore_include_sentence
 else
   Space2underscore.create_new_branch(underscore_include_sentence)


### PR DESCRIPTION
thanks for giving us the very useful tool.
in latest version I found a typo which causes an error and users can't seem to use the library.

please check!