### PR TITLE
Do not send notification email to owner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ before_install:
 script: "bundle exec rake spec:with_coveralls"
 
 notifications:
+  email: false
   slack: sachin21dev:3pEyff2UFnoCgl4NI0uxbsER


### PR DESCRIPTION
If `notifications.email` configuration is empty, it always sending an email notification to the owner(sachin21).